### PR TITLE
fix: Disable CLIENT_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@
 
 <br/>
 
+## Changes from upstream
+
+```sh
+vi .env
+  CLIENT_HOST=.
+```
+
+
+
 This project is a Game Boy Advance emulator that is freely licensed and works in any modern browser without plugins.
 
 It began as a re-skin of the [gbajs2](https://github.com/andychase/gbajs2) fork by andychase, but now supports the [mGBA wasm](https://github.com/thenick775/mgba/tree/feature/wasm) core through the use of emscripten, for a feature rich user experience.

--- a/admin/conf/conf.go
+++ b/admin/conf/conf.go
@@ -2,16 +2,17 @@ package conf
 
 import (
 	"fmt"
-	"github.com/GoAdminGroup/go-admin/modules/config"
-	"github.com/GoAdminGroup/go-admin/modules/language"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/GoAdminGroup/go-admin/modules/config"
+	"github.com/GoAdminGroup/go-admin/modules/language"
 )
 
 func NewAppConf() config.Config {
-	appID, clientDomain, dbHost, gbajsDsn, adminDsn := getValuesFromEnv()
+	appID, _, dbHost, gbajsDsn, adminDsn := getValuesFromEnv()
 
 	return config.Config{
 		Env: config.EnvProd,
@@ -34,7 +35,6 @@ func NewAppConf() config.Config {
 			},
 		},
 		AppID:                appID,
-		Domain:               clientDomain,
 		UrlPrefix:            "admin",
 		Theme:                "sword",
 		Title:                "gbajs3-admin",

--- a/admin/docker-compose.yaml
+++ b/admin/docker-compose.yaml
@@ -8,6 +8,10 @@ services:
             driver: json-file
         build:
             context: ${SERVICE_ADMIN:-.}
+            x-bake:
+                platforms:
+                    - linux/arm64
+                    - linux/amd64
         environment:
             - CLIENT_HOST=${CLIENT_HOST}
             - APP_ID=${ADMIN_APP_ID}

--- a/ake
+++ b/ake
@@ -1,0 +1,22 @@
+#!/usr/bin/env script.js
+
+const HELP = `
+`
+
+app
+  .name(PROJECT_NAME)
+  .enableCompletion()
+  .addHelpText('after', HELP.trimEnd())
+
+app.command('build [service]')
+  .description('Build and publish docker images')
+  .action((service) => {
+    switch (service) {
+      case 'admin':
+        return $`docker buildx bake -f ./admin/docker-compose.yaml --push`
+      case 'webserver':
+        return $`docker buildx bake -f ./gbajs3/docker-compose.yaml --push`
+      default:
+        return $`docker buildx bake -f ./postgres/docker-compose.yaml -f ./auth/docker-compose.yaml -f ./admin/docker-compose.yaml -f ./gbajs3/docker-compose.yaml --push`
+    }
+  })

--- a/ake
+++ b/ake
@@ -1,22 +1,52 @@
 #!/usr/bin/env script.js
 
 const HELP = `
-`
+`;
+
+app.name(PROJECT_NAME).enableCompletion().addHelpText('after', HELP.trimEnd());
 
 app
-  .name(PROJECT_NAME)
-  .enableCompletion()
-  .addHelpText('after', HELP.trimEnd())
-
-app.command('build [service]')
+  .command('build')
   .description('Build and publish docker images')
-  .action((service) => {
-    switch (service) {
-      case 'admin':
-        return $`docker buildx bake -f ./admin/docker-compose.yaml --push`
-      case 'webserver':
-        return $`docker buildx bake -f ./gbajs3/docker-compose.yaml --push`
-      default:
-        return $`docker buildx bake -f ./postgres/docker-compose.yaml -f ./auth/docker-compose.yaml -f ./admin/docker-compose.yaml -f ./gbajs3/docker-compose.yaml --push`
+  .argument('[services...]', 'Service', [
+    'webserver',
+    'admin',
+    'auth',
+    'postgres'
+  ])
+  .action((services) => {
+    for (const service of services) {
+      switch (service) {
+        case 'admin':
+          return $`
+docker buildx bake -f ./admin/docker-compose.yaml --push
+lzc-cli appstore copy-image gutenye/gba-admin-server  
+`;
+        case 'webserver':
+          return $`
+docker buildx bake -f ./gbajs3/docker-compose.yaml --push
+lzc-cli appstore copy-image gutenye/gba-webserver  
+`;
+        case 'auth':
+          return $`
+docker buildx bake -f ./auth/docker-compose.yaml --push
+lzc-cli appstore copy-image gutenye/gba-auth-server  
+`;
+
+        case 'postgres':
+          return $`
+docker buildx bake -f ./postgres/docker-compose.yaml --push
+lzc-cli appstore copy-image gutenye/gba-postgres
+`;
+      }
     }
-  })
+  });
+
+app.command('lazycat-upload-image [names]').action(async () => {
+  $`
+lzc-cli appstore copy-image gutenye/gba-webserver  
+lzc-cli appstore copy-image gutenye/gba-admin-server  
+lzc-cli appstore copy-image gutenye/gba-auth-server  
+lzc-cli appstore copy-image gutenye/gba-postgres 
+  `;
+});

--- a/auth/docker-compose.yaml
+++ b/auth/docker-compose.yaml
@@ -8,6 +8,10 @@ services:
             driver: json-file
         build:
             context: ${SERVICE_AUTH:-.}
+            x-bake:
+                platforms:
+                    - linux/arm64
+                    - linux/amd64
         environment:
             - CLIENT_HOST=${CLIENT_HOST}
             - PG_DB_HOST=${PG_DB_HOST}

--- a/gbajs3/docker-compose.yaml
+++ b/gbajs3/docker-compose.yaml
@@ -11,9 +11,12 @@ services:
             args:
                 CLIENT_HOST: ${CLIENT_HOST}
                 RELEASE_VERSION: ${RELEASE_VERSION}
+            x-bake:
+                platforms:
+                    - linux/arm64
+                    - linux/amd64
         ports:
-            - 443:443
-            - 80:80
+            - 3000:443
         environment:
             - CLIENT_HOST=${CLIENT_HOST}
         volumes:

--- a/gbajs3/vite.config.ts
+++ b/gbajs3/vite.config.ts
@@ -101,7 +101,8 @@ export default defineConfig(({ mode }) => {
           ]
         },
         workbox: {
-          globPatterns: ['**/*.{js,css,html,wasm}']
+          globPatterns: ['**/*.{js,css,html,wasm}'],
+          navigateFallbackDenylist: [/^\/admin/]
         },
         ...(withCOIServiceWorker
           ? {

--- a/postgres/docker-compose.yaml
+++ b/postgres/docker-compose.yaml
@@ -10,6 +10,10 @@ services:
             context: ${SERVICE_POSTGRES:-.}
             args:
                 PG_DB_USER: ${PG_DB_USER}
+            x-bake:
+                platforms:
+                    - linux/arm64
+                    - linux/amd64                                        
         environment:
             POSTGRES_USER: ${PG_DB_USER}
             POSTGRES_PASSWORD: ${PG_DB_PASSWORD}


### PR DESCRIPTION
1. Disable CLIENT_HOST: no need to set the domain
2. Support multiple platforms docker build: amd64 and arm64 

## Usage

```
.env
  CLIENT_HOST=.
```

Check ake file
